### PR TITLE
Draft: lifecycle support for image_transport_plugins

### DIFF
--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
@@ -36,9 +36,8 @@
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
+#include <image_transport/node_interfaces.hpp>
 #include <image_transport/simple_publisher_plugin.hpp>
-
-#include <rclcpp/node.hpp>
 
 #include <string>
 #include <vector>
@@ -62,7 +61,7 @@ public:
 protected:
   // Overridden to set up reconfigure server
   void advertiseImpl(
-          rclcpp::Node * node,
+          image_transport::NodeInterfaces::SharedPtr node_interfaces,
           const std::string &base_topic,
           rmw_qos_profile_t custom_qos,
           rclcpp::PublisherOptions options) override final;
@@ -71,7 +70,7 @@ protected:
                const PublishFn& publish_fn) const override final;
 
   rclcpp::Logger logger_;
-  rclcpp::Node * node_;
+  image_transport::NodeInterfaces::SharedPtr node_interfaces_;
 private:
   std::vector<std::string> parameters_;
   std::vector<std::string> deprecatedParameters_;

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -103,26 +103,27 @@ const struct ParameterDefinition kParameters[] =
 };
 
 void CompressedDepthPublisher::advertiseImpl(
-  rclcpp::Node * node,
+  image_transport::NodeInterfaces::SharedPtr node_interfaces,
   const std::string& base_topic,
   rmw_qos_profile_t custom_qos,
   rclcpp::PublisherOptions options)
 {
-  node_ = node;
+  node_interfaces_ = node_interfaces;
 
   typedef image_transport::SimplePublisherPlugin<sensor_msgs::msg::CompressedImage> Base;
-  Base::advertiseImpl(node, base_topic, custom_qos, options);
+  Base::advertiseImpl(node_interfaces_, base_topic, custom_qos, options);
 
   // Declare Parameters
-  uint ns_len = node->get_effective_namespace().length();
+  // TODO: original implementation uses get_effective_namespace of rclcpp::Node
+  uint ns_len = strlen(node_interfaces->base->get_namespace());
   std::string param_base_name = base_topic.substr(ns_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;
   auto callback = std::bind(&CompressedDepthPublisher::onParameterEvent, this, std::placeholders::_1,
-                            node->get_fully_qualified_name(), param_base_name);
+                            node_interfaces_->base->get_fully_qualified_name(), param_base_name);
 
-  parameter_subscription_ = rclcpp::SyncParametersClient::on_parameter_event<callbackT>(node, callback);
+  parameter_subscription_ = rclcpp::SyncParametersClient::on_parameter_event<callbackT>(node_interfaces_->topics, callback);
 
   for(const ParameterDefinition &pd : kParameters)
     declareParameter(param_base_name, pd);
@@ -133,10 +134,10 @@ void CompressedDepthPublisher::publish(
   const PublishFn& publish_fn) const
 {
   // Fresh Configuration
-  std::string cfg_format = node_->get_parameter(parameters_[FORMAT]).get_value<std::string>();
-  double cfg_depth_max = node_->get_parameter(parameters_[DEPTH_MAX]).get_value<double>();
-  double cfg_depth_quantization = node_->get_parameter(parameters_[DEPTH_QUANTIZATION]).get_value<double>();
-  int cfg_png_level = node_->get_parameter(parameters_[PNG_LEVEL]).get_value<int64_t>();
+  std::string cfg_format = node_interfaces_->parameters->get_parameter(parameters_[FORMAT]).get_value<std::string>();
+  double cfg_depth_max = node_interfaces_->parameters->get_parameter(parameters_[DEPTH_MAX]).get_value<double>();
+  double cfg_depth_quantization = node_interfaces_->parameters->get_parameter(parameters_[DEPTH_QUANTIZATION]).get_value<double>();
+  int cfg_png_level = node_interfaces_->parameters->get_parameter(parameters_[PNG_LEVEL]).get_value<int64_t>();
 
   sensor_msgs::msg::CompressedImage::SharedPtr compressed_image =
     encodeCompressedDepthImage(message,
@@ -165,15 +166,16 @@ void CompressedDepthPublisher::declareParameter(const std::string &base_name,
   rclcpp::ParameterValue param_value;
 
   try {
-    param_value = node_->declare_parameter(param_name, definition.defaultValue, definition.descriptor);
+    param_value = node_interfaces_->parameters->declare_parameter(param_name, definition.defaultValue,
+                                                                  definition.descriptor);
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
-    param_value = node_->get_parameter(param_name).get_parameter_value();
+    param_value = node_interfaces_->parameters->get_parameter(param_name).get_parameter_value();
   }
 
   // transport scoped parameter as default, otherwise we would overwrite
   try {
-    node_->declare_parameter(deprecated_name, param_value, definition.descriptor);
+    node_interfaces_->parameters->declare_parameter(deprecated_name, param_value, definition.descriptor);
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
   }
@@ -202,7 +204,7 @@ void CompressedDepthPublisher::onParameterEvent(ParameterEvent::SharedPtr event,
     //e.g. `color.image_raw.` + `compressedDepth` + `png_level`
     std::string recommendedName = name.substr(0, paramNameIndex + 1) + transport + name.substr(paramNameIndex);
 
-    rclcpp::Parameter recommendedValue = node_->get_parameter(recommendedName);
+    rclcpp::Parameter recommendedValue = node_interfaces_->parameters->get_parameter(recommendedName);
 
     // do not emit warnings if deprecated value matches
     if(it.second->value == recommendedValue.get_value_message())
@@ -211,7 +213,7 @@ void CompressedDepthPublisher::onParameterEvent(ParameterEvent::SharedPtr event,
     RCLCPP_WARN_STREAM(logger_, "parameter `" << name << "` is deprecated and ambiguous" <<
                                 "; use transport qualified name `" << recommendedName << "`");
 
-    node_->set_parameter(rclcpp::Parameter(recommendedName, it.second->value));
+      node_interfaces_->parameters->set_parameters({rclcpp::Parameter(recommendedName, it.second->value)});
   }
 }
 

--- a/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
@@ -38,8 +38,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <image_transport/simple_publisher_plugin.hpp>
-
-#include <rclcpp/node.hpp>
+#include <image_transport/node_interfaces.hpp>
 
 #include "compressed_image_transport/compression_common.h"
 
@@ -62,7 +61,7 @@ public:
 protected:
   // Overridden to set up reconfigure server
   void advertiseImpl(
-      rclcpp::Node* node,
+      image_transport::NodeInterfaces::SharedPtr node_interfaces,
       const std::string& base_topic,
       rmw_qos_profile_t custom_qos,
       rclcpp::PublisherOptions options) override;
@@ -71,7 +70,7 @@ protected:
                const PublishFn& publish_fn) const override;
 
   rclcpp::Logger logger_;
-  rclcpp::Node * node_;
+  image_transport::NodeInterfaces::SharedPtr node_interfaces_;
 
 private:
   std::vector<std::string> parameters_;

--- a/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
@@ -41,6 +41,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <image_transport/simple_subscriber_plugin.hpp>
+#include <image_transport/node_interfaces.hpp>
 
 #include "compressed_image_transport/compression_common.h"
 
@@ -62,7 +63,7 @@ public:
 protected:
 
   void subscribeImpl(
-      rclcpp::Node * ,
+      image_transport::NodeInterfaces::SharedPtr node_interfaces,
       const std::string& base_topic,
       const Callback& callback,
       rmw_qos_profile_t custom_qos,
@@ -72,7 +73,7 @@ protected:
                         const Callback& user_cb) override;
 
   rclcpp::Logger logger_;
-  rclcpp::Node * node_;
+  image_transport::NodeInterfaces::SharedPtr node_interfaces_;
 
 private:
   std::vector<std::string> parameters_;

--- a/theora_image_transport/include/theora_image_transport/theora_publisher.h
+++ b/theora_image_transport/include/theora_image_transport/theora_publisher.h
@@ -34,11 +34,10 @@
 
 #include "theora_image_transport/compression_common.h"
 
-#include <rclcpp/node.hpp>
-
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
 
+#include <image_transport/node_interfaces.hpp>
 #include <image_transport/simple_publisher_plugin.hpp>
 #include <cv_bridge/cv_bridge.hpp>
 #include <std_msgs/msg/header.hpp>
@@ -66,7 +65,7 @@ public:
 
 protected:
   void advertiseImpl(
-    rclcpp::Node* node,
+    image_transport::NodeInterfaces::SharedPtr node_interfaces,
     const std::string &base_topic,
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) override;
@@ -98,7 +97,7 @@ protected:
   mutable std::vector<theora_image_transport::msg::Packet> stream_header_;
 
   rclcpp::Logger logger_;
-  rclcpp::Node * node_;
+  image_transport::NodeInterfaces::SharedPtr node_interfaces_;
 
 private:
   std::vector<std::string> parameters_;

--- a/theora_image_transport/include/theora_image_transport/theora_subscriber.h
+++ b/theora_image_transport/include/theora_image_transport/theora_subscriber.h
@@ -34,8 +34,7 @@
 
 #include "theora_image_transport/compression_common.h"
 
-#include <rclcpp/node.hpp>
-
+#include <image_transport/node_interfaces.hpp>
 #include <image_transport/simple_subscriber_plugin.hpp>
 #include <theora_image_transport/msg/packet.hpp>
 
@@ -61,7 +60,7 @@ public:
 protected:
   // Overridden to bump queue_size, otherwise we might lose headers
   void subscribeImpl(
-    rclcpp::Node* node,
+    image_transport::NodeInterfaces::SharedPtr node_interfaces,
     const std::string &base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos,
@@ -89,7 +88,7 @@ protected:
   sensor_msgs::msg::Image::SharedPtr latest_image_;
 
   rclcpp::Logger logger_;
-  rclcpp::Node * node_;
+  image_transport::NodeInterfaces::SharedPtr node_interfaces_;
 
 private:
   std::vector<std::string> parameters_;

--- a/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
+++ b/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
@@ -39,9 +39,8 @@
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
+#include <image_transport/node_interfaces.hpp>
 #include <image_transport/simple_publisher_plugin.hpp>
-
-#include <rclcpp/node.hpp>
 
 #include "zstd_image_transport/zstd_common.hpp"
 
@@ -62,7 +61,7 @@ public:
 protected:
   // Overridden to set up reconfigure server
   void advertiseImpl(
-    rclcpp::Node * node,
+    image_transport::NodeInterfaces::SharedPtr node_interfaces,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) override;
@@ -72,7 +71,7 @@ protected:
     const PublishFn & publish_fn) const override;
 
   rclcpp::Logger logger_;
-  rclcpp::Node * node_;
+  image_transport::NodeInterfaces::SharedPtr node_interfaces_;
 
 private:
   std::vector<std::string> parameters_;

--- a/zstd_image_transport/include/zstd_image_transport/zstd_subscriber.hpp
+++ b/zstd_image_transport/include/zstd_image_transport/zstd_subscriber.hpp
@@ -37,11 +37,11 @@
 #include <string>
 #include <vector>
 
-#include <rclcpp/node.hpp>
 #include <rclcpp/subscription_options.hpp>
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
+#include <image_transport/node_interfaces.hpp>
 #include <image_transport/simple_subscriber_plugin.hpp>
 
 #include "zstd_image_transport/zstd_common.hpp"
@@ -62,7 +62,7 @@ public:
 
 protected:
   void subscribeImpl(
-    rclcpp::Node *,
+    image_transport::NodeInterfaces::SharedPtr node_interfaces,
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos,
@@ -73,7 +73,7 @@ protected:
     const Callback & user_cb) override;
 
   rclcpp::Logger logger_;
-  rclcpp::Node * node_;
+  image_transport::NodeInterfaces::SharedPtr node_interfaces_;
 };
 
 }  // namespace zstd_image_transport

--- a/zstd_image_transport/src/zstd_subscriber.cpp
+++ b/zstd_image_transport/src/zstd_subscriber.cpp
@@ -58,16 +58,16 @@ std::string ZstdSubscriber::getTransportName() const
 }
 
 void ZstdSubscriber::subscribeImpl(
-  rclcpp::Node * node,
+  image_transport::NodeInterfaces::SharedPtr node_interfaces,
   const std::string & base_topic,
   const Callback & callback,
   rmw_qos_profile_t custom_qos,
   rclcpp::SubscriptionOptions options)
 {
-  node_ = node;
-  logger_ = node->get_logger();
+  node_interfaces_ = node_interfaces;
+  logger_ = node_interfaces_->logging->get_logger();
   typedef image_transport::SimpleSubscriberPlugin<sensor_msgs::msg::CompressedImage> Base;
-  Base::subscribeImpl(node, base_topic, callback, custom_qos, options);
+  Base::subscribeImpl(node_interfaces_, base_topic, callback, custom_qos, options);
 }
 
 void ZstdSubscriber::internalCallback(


### PR DESCRIPTION
Mainly for keeping an overview of the changes...

Depends on the corresponding [MR](https://github.com/authaldo/image_common/pull/1) in the [image_transport fork](https://github.com/authaldo/image_common)